### PR TITLE
forEach

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,11 @@ Start the queue.
 
 Stop the queue.  This does not cancel working workers - it just ceases the creation of new workers.
 
+### queue.forEach()
+
+Execute a function on each member currently in the queue without removing it from the queue.
+This function is sequential in nature.
+
 ## Contributing
 
 Please maintain the existing style - but do open a pull request if you have a bugfix or a cool feature.

--- a/src/limiting-queue.js
+++ b/src/limiting-queue.js
@@ -229,4 +229,22 @@ module.exports = function LimitingQueue(opts) {
     this.stop = function() {
         working = false;
     }.bind(this);//stop()
+
+    /**
+     *  Execute a function on each member currently in the queue without removing it from the queue.
+     *  This function is sequential in nature.
+     *  
+     *  @param callback The funciton to be called on each member of the queue.
+     */
+    this.forEach = function(callback) {
+        var current = queueHead;
+        while (current) {
+            try {
+                callback(current.payload);
+            } catch (e) {//Try
+                //There's just nothing to be done here.
+            } //Catch Error
+            current = current.next;
+        }
+    }.bind(this);//forEach(callback)
 }

--- a/test/limiting-queue.js
+++ b/test/limiting-queue.js
@@ -313,5 +313,31 @@ describe('Limiting Queue', function() {
                 this.queue.start();
             });
         });
+        describe('forEach', function() {
+            it('Should iterate over all items, in order, without removing them.', function() {
+                this.queue.stop();
+                for (var i = 0; i < SIZE; i++) {
+                    expect(this.queue.push(i)).to.be.true;
+                }
+                expect(this.queue.size()).to.equal(SIZE);
+                var j = 0;
+                this.queue.forEach(function(item) {
+                    expect(item).to.equal(j);
+                    j++;
+                });
+                expect(this.queue.size()).to.equal(SIZE);
+            });
+            it('Should not be perturbed by errors.', function() {
+                this.queue.stop();
+                for (var i = 0; i < SIZE; i++) {
+                    expect(this.queue.push(i)).to.be.true;
+                }
+                expect(function() {
+                    this.queue.forEach(function(item) {
+                        throw new Error("Testing");
+                    });
+                }.bind(this)).to.not.throw();
+            });
+        });
     });
 });


### PR DESCRIPTION
Add a forEach function to iterate over the members in the queue without removing them from the queue.  This could be used for queue interrupting and dumping.